### PR TITLE
limit indexing to docs templates - use pageTitle if title is missing

### DIFF
--- a/lib/broccoli/hbs-content-filter.js
+++ b/lib/broccoli/hbs-content-filter.js
@@ -44,7 +44,8 @@ module.exports = class HBSContentFilter extends Filter {
 
     let output = {
       title: title.contents ? title.contents.join('') : null,
-      body: body.join('')
+      body: body.join(''),
+      rawTemplate: content
     };
 
     return JSON.stringify(output);

--- a/lib/broccoli/search-indexer.js
+++ b/lib/broccoli/search-indexer.js
@@ -48,7 +48,10 @@ module.exports = class SearchIndexCompiler extends Writer {
 
     for (let filePath of this.listFiles()) {
       if (/\.template-contents$/.test(filePath)) {
-        yield this.buildTemplateDocument(filePath);
+        // limit search indexing to docs templates
+        if (/\/docs\//.test(filePath)) {
+          yield this.buildTemplateDocument(filePath);
+        }
       } else if (new RegExp(`${projectName}.json`).test(filePath)) {
         yield* this.buildApiItemDocuments(filePath);
       }
@@ -71,10 +74,21 @@ module.exports = class SearchIndexCompiler extends Writer {
     }
 
     if (routePath && routePath.indexOf('components/') !== 0) {
+
+      let title = normalizeText(contents.title);
+      // if we weren't able to find a title in the page attempt to pull it
+      // from our pulse hero's pageTitle attribute
+      if (!title) {
+        let pageTitleMatches = contents.rawTemplate.match(/pageTitle='([^']*)'/)
+        if (pageTitleMatches) {
+          title = pageTitleMatches[1];
+        }
+      }
+
       return {
         id: `template:${routePath}`,
         type: 'template',
-        title: normalizeText(contents.title),
+        title,
         text: normalizeText(contents.body),
         route: routePath.replace(/\//g, '.'),
         keywords: [], // TODO allow for specifying keywords


### PR DESCRIPTION
This PR resolves DS-262 by modifying the ecad search indexing code to:

* restrict indexing to only docs templates (those containing `/docs/` in the route)
* attempt to generate the template's title from the hero component's pageTitle attribute if we couldn't find a h1 in the page by itself