### PR TITLE
clean up search results markup - limit to a single match

### DIFF
--- a/addon/components/docs-header/search-result/component.js
+++ b/addon/components/docs-header/search-result/component.js
@@ -75,13 +75,11 @@ export default Component.extend({
       });
 
       return matches;
-    }, [])
-      .slice(0, 5)
-      .join(' &middot; ');
+    }, [])[0]
   }),
 
   _highlight(text, start, length) {
-    return `${text.slice(0, start)}<em class='docs-bg-yellow'>${text.slice(start, start + length)}</em>${text.slice(start + length)}`;
+    return `${text.slice(0, start)}<span class='ecad__search-result__highlight'>${text.slice(start, start + length)}</span>${text.slice(start + length)}`;
   },
 
   'data-test-search-result': true,

--- a/addon/components/docs-header/search-result/template.hbs
+++ b/addon/components/docs-header/search-result/template.hbs
@@ -1,17 +1,11 @@
 {{#link-to
   params=linkArgs
-  class=(concat
-    "docs-block docs-py-2 docs-px-3 docs-text-black docs-no-underline hover:docs-bg-grey-lighter "
-    (if selected "docs-bg-grey-lighter")
-  )
+  class="ecad__search-result__link"
 }}
-  <div class="docs-flex docs-items-center">
-    {{svg-jar icon height=28 width=28 class="docs-mr-2 docs-flex-no-shrink"}}
-    <span class='docs-truncate'>
-      {{result.document.title}}
-    </span>
-  </div>
-  <small class='docs-text-grey-dark docs-inline-block'>
+  <h4 class="ecad__search-result__title">
+    {{result.document.title}}
+  </h4>
+  <p class='ecad__search-result__text'>
     {{{matches}}}
-  </small>
+  </p>
 {{/link-to}}

--- a/addon/components/docs-header/search-results/template.hbs
+++ b/addon/components/docs-header/search-results/template.hbs
@@ -5,20 +5,21 @@
     clickOutsideToClose=true
     onClose=(action 'clearSearch')
     targetAttachment='bottom left'
-    constraints=(array (hash to='window' attachment='together' pin=true))}}
-
-    <ul class="docs-w-76 docs-bg-white docs-shadow-md docs-list-reset" data-test-search-result-list>
-      {{#each (take 5 searchResults) as |result index|}}
+    constraints=(array (hash to='window' attachment='together' pin=true))
+  }}
+    <ul class="ecad__search-results-list" data-test-search-result-list>
+      {{#each searchResults as |result index|}}
         <li>
           {{docs-header/search-result
             result=result
             query=query
             selected=(eq index selectedIndex)
             on-mouse-enter=(action 'selectResult' index)
-            on-click=(action 'clearSearch')}}
+            on-click=(action 'clearSearch')
+          }}
         </li>
       {{else}}
-        <li class='docs-block docs-py-1 docs-px-3 docs-text-grey-dark docs-no-underline'>
+        <li class='ecad__search-result__empty'>
           No results.
         </li>
       {{/each}}


### PR DESCRIPTION
This PR lays the groundwork for the DS-260 user story (not linked because this fork is currently public) by cleaning up some of the markup generated in the search results modal and giving the elements some `ecad__` prefixed class names for targeting and styling in Pulse.

Markup after:
<img width="671" alt="screenshot 2018-11-06 at 22 43 23" src="https://user-images.githubusercontent.com/7144173/48098862-d32e0800-e215-11e8-8cf1-dacb921f5ceb.png">
