### PR TITLE
Remove docs footer

### DIFF
--- a/addon/components/docs-viewer/x-main/template.hbs
+++ b/addon/components/docs-viewer/x-main/template.hbs
@@ -1,8 +1,3 @@
 <div data-current-page-index-target>
   {{yield}}
-
-  <div class="ecad__footer" data-test-edit-page-link>
-    <a href={{editCurrentPageUrl}} class='ecad__footer__edit-page-link'>Edit this page</a>
-    <a href="javascript:window.scrollTo(0, 0);" class='ecad__footer__scroll-to-top-link'>Back to top</a>
-  </div>
 </div>

--- a/addon/components/docs-viewer/x-main/template.hbs
+++ b/addon/components/docs-viewer/x-main/template.hbs
@@ -1,39 +1,8 @@
 <div data-current-page-index-target>
   {{yield}}
 
-  <div class="docs-mt-16 docs-mb-8" data-test-edit-page-link>
-    <a href={{editCurrentPageUrl}}
-      class='docs-transition docs-text-grey-darkest docs-opacity-50 docs-text-xs
-      hover:docs-opacity-75 docs-no-underline docs-border-b docs-border-grey hover:docs-border-grey-darkest'>
-      Edit this page
-    </a>
-  </div>
-</div>
-
-<div class="docs-mt-16 docs-pb-16 docs-border-t docs-border-grey-lighter docs-pt-4 docs-flex">
-  <div class="docs-w-1/2">
-    {{#if docsRoutes.previous}}
-      <div class='docs-text-xs docs-text-grey-dark'>
-        Previous
-      </div>
-      {{#link-to params=docsRoutes.previous.route
-        class='docs-text-grey-darkest docs-text-large-4 docs-font-light docs-no-underline
-        docs-border-b docs-border-grey hover:docs-border-grey-darkest docs-transition'}}
-        {{docsRoutes.previous.label}}
-      {{/link-to}}
-    {{/if}}
-  </div>
-
-  <div class="docs-w-1/2 docs-text-right" data-test-next-link>
-    {{#if docsRoutes.next}}
-      <div class='docs-text-xs docs-text-grey-dark'>
-        Next
-      </div>
-      {{#link-to params=docsRoutes.next.route
-        class='docs-text-grey-darkest docs-text-large-4 docs-font-light docs-no-underline
-        docs-border-b docs-border-grey hover:docs-border-grey-darkest docs-transition'}}
-        {{docsRoutes.next.label}}
-      {{/link-to}}
-    {{/if}}
+  <div class="ecad__footer" data-test-edit-page-link>
+    <a href={{editCurrentPageUrl}} class='ecad__footer__edit-page-link'>Edit this page</a>
+    <a href="javascript:window.scrollTo(0, 0);" class='ecad__footer__scroll-to-top-link'>Back to top</a>
   </div>
 </div>


### PR DESCRIPTION
This PR works towards resolving DS-281 by removing the markup for the `Edit this page` link and next/previous nav links (that we're already hiding in pulse) - this will allow us to implement our own docs footer