### PR TITLE
Include pulse-docs/heading properties in search

### DIFF
--- a/lib/broccoli/hbs-content-filter.js
+++ b/lib/broccoli/hbs-content-filter.js
@@ -14,14 +14,18 @@ module.exports = class HBSContentFilter extends Filter {
     let parents = new Map();
     let title = { level: Infinity, node: null, contents: null };
     let body = [];
-
+    let keywords = [];
     syntax.traverse(syntax.preprocess(content), {
       Program(node) {
         addContentNodes(parents, node, node.body);
       },
 
       ElementNode(node) {
-        addContentNodes(parents, node, node.children);
+        if (isPulseHeadingNode(node)) {
+          addPulseHeadingNode(keywords, node);
+        } else {
+          addContentNodes(parents, node, node.children);
+        }
       },
 
       TextNode(node) {
@@ -45,6 +49,7 @@ module.exports = class HBSContentFilter extends Filter {
     let output = {
       title: title.contents ? title.contents.join('') : null,
       body: body.join(''),
+      keywords,
       rawTemplate: content
     };
 
@@ -65,5 +70,21 @@ function addContentNodes(parents, parent, candidates) {
     if (candidate.type === 'TextNode') {
       parents.set(candidate, parent);
     }
+  }
+}
+
+function isPulseHeadingNode(node) {
+  return (
+    node.children.length &&
+    node.children[0].path &&
+    node.children[0].path.original === 'pulse-docs/heading'
+  );
+}
+
+function addPulseHeadingNode(keywords, node) {
+  let pulseHeadingProps = node.children[0].hash.pairs || [];
+  let property = pulseHeadingProps.find(prop => prop.key === 'property');
+  if (property) {
+    keywords.push(property.value.value);
   }
 }

--- a/lib/broccoli/search-indexer.js
+++ b/lib/broccoli/search-indexer.js
@@ -19,7 +19,7 @@ module.exports = class SearchIndexCompiler extends Writer {
   build() {
     let writer = this;
     let documents = {};
-    let index = lunr(function() {
+    let index = lunr(function () {
       this.ref('id');
       this.metadataWhitelist = ['position'];
 
@@ -73,13 +73,12 @@ module.exports = class SearchIndexCompiler extends Writer {
       routePath = relativePath.replace(`${modulePrefix}/templates/`, '').replace(/\.template-contents$/, '');
     }
 
-    if (routePath && routePath.indexOf('components/') !== 0) {
-
+    if (routePath && (routePath.includes('components/') || routePath.includes('foundations/'))) {
       let title = normalizeText(contents.title);
       // if we weren't able to find a title in the page attempt to pull it
       // from our pulse hero's pageTitle attribute
       if (!title) {
-        let pageTitleMatches = contents.rawTemplate.match(/pageTitle='([^']*)'/)
+        let pageTitleMatches = contents.rawTemplate.match(/pageTitle='([^']*)'/);
         if (pageTitleMatches) {
           title = pageTitleMatches[1];
         }
@@ -91,7 +90,7 @@ module.exports = class SearchIndexCompiler extends Writer {
         title,
         text: normalizeText(contents.body),
         route: routePath.replace(/\//g, '.'),
-        keywords: [], // TODO allow for specifying keywords
+        keywords: contents.keywords
       };
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-addon-docs",
-  "version": "0.6.4-intercom",
+  "version": "0.6.5-intercom",
   "description": "Easy, beautiful docs for your OSS Ember addons",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Fixes [DS-298](https://designsystems.atlassian.net/browse/DS-298)

ECAD builds its search index based of text nodes and (rightfully so) ignores attributes in HTML elements or moustache expressions. The `pulse-docs/heading` component we've built takes a `property` argument that is core to the component/class being documented as it matches verbatim what engineers would be using. 

In order to make them searchable we identify instances of this component while traversing the AST and piggyback on ECAD's keywords functionality which are unused by default.

Before:
![image](https://user-images.githubusercontent.com/1145726/49441430-55cac880-f7be-11e8-8c5d-6847c5c7440b.png)

After:
![image](https://user-images.githubusercontent.com/1145726/49441423-506d7e00-f7be-11e8-9bc1-5fd9c8926268.png)
