### PR TITLE
upgrade ember-responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-href-to": "^1.15.1",
     "ember-keyboard": "^4.0.0",
     "ember-modal-dialog": "2.4.3",
-    "ember-responsive": "^3.0.0-beta.1",
+    "ember-responsive": "^3.0.3",
     "ember-router-scroll": "^1.0.0",
     "ember-svg-jar": "^1.2.2",
     "ember-tether": "^1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-addon-docs",
-  "version": "0.6.5-intercom",
+  "version": "0.6.6-intercom",
   "description": "Easy, beautiful docs for your OSS Ember addons",
   "keywords": [
     "ember-addon",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,10 +4622,10 @@ ember-resolver@^5.0.1:
     ember-cli-version-checker "^2.0.0"
     resolve "^1.3.3"
 
-ember-responsive@^3.0.0-beta.1:
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/ember-responsive/-/ember-responsive-3.0.0-beta.3.tgz#63f4f5cad179399e40cd6a591bb2677c4cc0a874"
-  integrity sha512-C7E0C/hKy5BT5tjHxzyLItc7Bq/Ci/IoUucQ1OQts81Uxq0SG4srjbfO0ZlDq6nbV7xxe9xdPMPD5tPHii8W2w==
+ember-responsive@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/ember-responsive/-/ember-responsive-3.0.3.tgz#1939f71d874e660af8314203084ba2b309aafd24"
+  integrity sha512-FXRSmUoPXCaMGtm5ygxco4cs/q7ce7eGGUMevF3hv8RFxvm2C9VTwV8IaZCTiB0bQc5IP913tBi/X9S8ihDguw==
   dependencies:
     ember-cli-babel "^6.6.0"
 


### PR DESCRIPTION
part of https://github.com/intercom/intercom/issues/144338

This should solve:

```
vendor.js:40849 Error while processing route: index Assertion Failed: You must call `this._super(...arguments);` when overriding `init` on a framework object. Please update <dummy@service:media::ember228> to call `this._super(...arguments);` from `init`. Error: Assertion Failed: You must call `this._super(...arguments);` when overriding `init` on a framework object. Please update <dummy@service:media::ember228> to call `this._super(...arguments);` from `init`.
```